### PR TITLE
feat: Add behaviour field to type schema

### DIFF
--- a/d3-scripts/src/d3_scripts/schemas/type.json
+++ b/d3-scripts/src/d3_scripts/schemas/type.json
@@ -57,6 +57,24 @@
           "type": "string"
         },
         "description": "An array of MAC addresses"
+      },
+      "behaviours": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "GUID for the behaviour"
+            },
+            "name": {
+              "type": "string",
+              "description": "The behaviour name"
+            }
+          }
+        },
+        "description": "An array of behaviours"
       }
     },
     "required": ["id"]


### PR DESCRIPTION
This PR address adding a `behaviours` field to the `type.json` schema

I have implemented it as an array of objects with [optional] fields `id` and `name` so we can identify what the string matches in the `behaviour.json` schema