### PR TITLE
style: add pre-commit Python checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
     -   id: mixed-line-ending
         # prevent Windows CRLF line ending, and use LF (Unix) line ending
         args: ["--fix=lf"]
+    # Python-only-checks
+    -   id: check-ast # check whether valid Python
+    -   id: check-docstring-first # check Python doc-string location
+    -   id: debug-statements # forbid committing Python debug statements


### PR DESCRIPTION
Checks for very basic Python errors, like:
  - is valid python?
  - are module docstrings before the import statements
  - are there any debug (e.g. `breakpoint()`) statements

It may be worth adding https://github.com/psf/black and [isort](https://pycqa.github.io/isort/) too, but that would be a pretty substantial change (lots of lines changed in `git diff`)