### PR TITLE
test: replace flaky nquiringminds.com uri

### DIFF
--- a/d3-scripts/tests/__fixtures__/invalid-uri/valid-uri.type.d3.yaml
+++ b/d3-scripts/tests/__fixtures__/invalid-uri/valid-uri.type.d3.yaml
@@ -2,7 +2,11 @@ credentialSubject:
   id: 0de372d6-4ccc-46d3-a1ce-eb73e89b9b73
   macAddresses:
   - C5-5E-87-89-3C-3B
-  manufacturer: NquiringMinds
-  manufacturerUri: https://nquiringminds.com
-  name: nqminds
+  manufacturer: Connectivity Test Server
+  # captive portal URL used for connectivity tests
+  # on Chromium open-source projects
+  # List of other URIs we can use for testing
+  # https://github.com/NickSto/uptest/blob/master/captive-portals.md
+  manufacturerUri: https://gstatic.com/generate_204
+  name: valid-uri-resolves-test
 type: d3-device-type-assertion


### PR DESCRIPTION
Tests are really flaky, since our https://nquiringminds.com website seems to be constantly dropping requests.