### PR TITLE
fix: sort input to d3export for consistent CSVs

### DIFF
--- a/d3-scripts/src/d3_scripts/d3_build_db.py
+++ b/d3-scripts/src/d3_scripts/d3_build_db.py
@@ -17,7 +17,8 @@ def d3_build_db():
         d3_build()
 
     print("Exporting D3 claims...")
-    files_to_process = list(json_dir.glob("**/*.d3.json"))
+    # sort so that the *.csv files are relatively consistent
+    files_to_process = sorted(json_dir.glob("**/*.d3.json"))
 
     create_csv_templates()
 


### PR DESCRIPTION
Sort the input files to d3export for consistent CSVs.

`glob()` picks an essentially random order: just whatever's most efficient for operating system.

Currently, we only publish changes to 'D3DB/' to the `csv` branch, so anything we can do to reduce unnecessary changes is a good thing.