### PR TITLE
Except errors in build due to unimplemented features

### DIFF
--- a/d3-scripts/src/d3_scripts/d3_build.py
+++ b/d3-scripts/src/d3_scripts/d3_build.py
@@ -25,6 +25,7 @@ def claim_handler(file_name):
 def d3_build(
     d3_files: typing.Iterable[Path] = yaml_dir.glob("**/*.yaml"),
     check_uri_resolves: bool = True,
+    pass_on_failure: bool = False,
 ):
     """Build compressed D3 files from D3 YAML files
 
@@ -35,6 +36,8 @@ def d3_build(
         check_uri_resolves: Whether to check that URIs/refs resolve.
                             This can be very slow, so you may want to
                             leave this off normally.
+        pass_on_failure: Whether to allow build to continue on failure 
+                         to validate file claims
     """
     print("Compiling D3 claims...")
     bar_format = "{desc: <20}|{bar}| {percentage:3.0f}% [{elapsed}]"
@@ -64,6 +67,7 @@ def d3_build(
         process_claim_file,
         behaviour_jsons=behaviour_jsons,
         check_uri_resolves=check_uri_resolves,
+        pass_on_failure=pass_on_failure,
     )
     pbar.update(10)
 
@@ -102,6 +106,11 @@ def cli(argv=None):
         help="""Check that URIs/refs resolve.
         This can be very slow, so you may want to leave this off normally.""",
     )
+    parser.add_argument(
+        "--pass-on-failure",
+        help="Allow build to continue on failure to validate file claims.",
+        action='store_true',
+    )
     debug_level_group = parser.add_mutually_exclusive_group()
     debug_level_group.add_argument(
         "--verbose",
@@ -133,6 +142,7 @@ def cli(argv=None):
           for d3_file in Path(d3_folder).glob("**/*.yaml")
         ),
         check_uri_resolves=args.check_uri_resolves,
+        pass_on_failure=args.pass_on_failure,
     )
 
 

--- a/d3-scripts/src/d3_scripts/d3_build.py
+++ b/d3-scripts/src/d3_scripts/d3_build.py
@@ -36,7 +36,7 @@ def d3_build(
         check_uri_resolves: Whether to check that URIs/refs resolve.
                             This can be very slow, so you may want to
                             leave this off normally.
-        pass_on_failure: Whether to allow build to continue on failure 
+        pass_on_failure: Whether to allow build to continue on failure
                          to validate file claims
     """
     print("Compiling D3 claims...")

--- a/d3-scripts/src/d3_scripts/d3_utils.py
+++ b/d3-scripts/src/d3_scripts/d3_utils.py
@@ -73,6 +73,7 @@ def validate_d3_claim_files(
 def process_claim_file(
     yaml_file_name: str, behaviour_jsons: BehaviourJsons,
     check_uri_resolves: bool,
+    pass_on_failure: bool,
 ) -> typing.List[Warning]:
     """Processes a single D3 claim file.
     Checks include:
@@ -126,5 +127,8 @@ def process_claim_file(
 
         return [*uri_warnings]
     except FileNotFoundError as err:
-        print(f"WARNING! Skipping claim {yaml_file_name} due to error: ${err}")
-        return []
+        if (pass_on_failure):
+            print(f"WARNING! Skipping claim {yaml_file_name} due to error: ${err}")
+            return []
+        else:
+            raise err

--- a/d3-scripts/src/d3_scripts/yaml_tools.py
+++ b/d3-scripts/src/d3_scripts/yaml_tools.py
@@ -26,7 +26,7 @@ def is_valid_yaml_claim(file_name: str):
         Boolean indicating if the file is valid else throws an exception
     """
     file_path = Path(file_name)
-    suffixes = file_path.suffixes
+    suffixes = file_path.suffixes[-3:]
     file_str = file_path.relative_to(file_path.parents[2])
     example = "e.g. example_claim.type.d3.yaml"
 

--- a/examples/manufacturers/Amazon/Echo/echo.behaviour.d3.yaml
+++ b/examples/manufacturers/Amazon/Echo/echo.behaviour.d3.yaml
@@ -3,7 +3,7 @@ type: d3-device-type-behaviour
 # Subject if the verfied credential
 credentialSubject:
   # The GUID denoting the device rule
-  id: aa92ebae-4928-4456-b597-cbd7657e9e83
+  id: fc4d5a51-f985-4de1-a157-51ea9ca5e9c0
   # Rules are specified as an array with two keys name and matches
   ruleName: "Example Device"
   rules:

--- a/examples/manufacturers/Brother/Printers/MFC-J6920DW/MFC-J6920DW.type.d3.yaml
+++ b/examples/manufacturers/Brother/Printers/MFC-J6920DW/MFC-J6920DW.type.d3.yaml
@@ -3,7 +3,7 @@ credentialSubject:
   # unique identifiers
   id: aa92ebae-4928-4456-b597-cbd7657e9e83
   #aliases is an URI
-  aliases: ["www.manysecured.net/aa92ebae-4928-4456-b597-cbd7657e9e83", "www.brother.com/aa92ebae-4928-4456-b597-cbd7657e9e83"]
+  aliases: '["www.manysecured.net/aa92ebae-4928-4456-b597-cbd7657e9e83", "www.brother.com/aa92ebae-4928-4456-b597-cbd7657e9e83"]'
 
     #general manufacturer information
   manufacturer:     Brother UK Ltd

--- a/examples/manufacturers/Brother/Printers/firmwares/brother-firmware MFC15.05.95.firmware.d3.yaml
+++ b/examples/manufacturers/Brother/Printers/firmwares/brother-firmware MFC15.05.95.firmware.d3.yaml
@@ -1,7 +1,7 @@
-type: d3-firmware-assertion
+type: d3-firmware
 credentialSubject:
   # unique identifiers
-  id: 76ac379a-5f93-418b-9a34-5c715042fdc2
+  id: 4bb46bc8-4f7e-4f1f-9ccb-defe6c508fa6
 
   #general manufacturer information
   version:   16.03.03


### PR DESCRIPTION
 fix errors raised when attempting to build and export examples directory manufacturers due to unimplemented features by trying and excepting failure, skipping files which do not build successfully and printing warning to terminal