### PR TITLE
Add parent child info to type claims

### DIFF
--- a/D3DB/tables.sql
+++ b/D3DB/tables.sql
@@ -10,7 +10,16 @@ CREATE TABLE "type" (
   "tags" TEXT,
   "macaddresses" TEXT,
   "behaviour" TEXT,
+  "parents" TEXT,
+  "children" TEXT,
  PRIMARY KEY("id")
+)
+
+CREATE TABLE "firmware" (
+  "id" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "versions" TEXT
+  "behaviour" TEXT
 )
 
 CREATE TABLE "behaviour" (

--- a/d3-scripts/src/d3_scripts/build_type_map.py
+++ b/d3-scripts/src/d3_scripts/build_type_map.py
@@ -10,7 +10,7 @@ def build_type_map(type_jsons):
         try:
             type = type_map[type_id]
         except KeyError:
-            raise KeyError(f"Parent type with id {type_id} of {list(type_graph.successors(type_id))} doesn't exist")
+            raise KeyError(f"Parent type with id {type_id} of {list(type_graph.predecessors(type_id))} doesn't exist")
         parents = type["credentialSubject"].get("parents", [])
         inherited_properties = {}
         for parent in parents:
@@ -24,4 +24,7 @@ def build_type_map(type_jsons):
                 except KeyError:
                     raise KeyError(f"Attempted to inherit missing property {property} from {parent_id} in {type_id}")
         type_map[type_id]["credentialSubject"] = {**inherited_properties, **type["credentialSubject"]}
+        type_map[type_id]["credentialSubject"]["children"] = [
+            {"id": child_id} for child_id in list(type_graph.successors(type_id))
+        ]
     return type_map

--- a/d3-scripts/src/d3_scripts/d3_constants.py
+++ b/d3-scripts/src/d3_scripts/d3_constants.py
@@ -20,7 +20,10 @@ csv_headers = {
     "type": [
         "id", "aliases", "manufacturer", "manufactureruri", "modelnumber",
         "modelsupporturi", "modelinformationuri", "name", "tags",
-        "macaddresses", "behaviour"
+        "macaddresses", "behaviour", "parents", "children"
+    ],
+    "firmware": [
+        "id", "type", "versions", "behaviour"
     ],
     "behaviour": [
         "id", "ruleid", "rulename", "malicious"

--- a/d3-scripts/src/d3_scripts/d3_utils.py
+++ b/d3-scripts/src/d3_scripts/d3_utils.py
@@ -19,6 +19,7 @@ from .check_behaviours_resolve import check_behaviours_resolve, BehaviourMap
 from .resolve_behaviour_rules import resolve_behaviour_rules
 from .d3_constants import d3_type_codes
 from typing import Sequence, Mapping, Any
+from copy import deepcopy
 
 TypeJson = Mapping[str, Any]
 TypeJsons = Sequence[TypeJson]
@@ -125,7 +126,8 @@ def process_claim_file(
 
         if claim["type"] == d3_type_codes["type"]:
             claim_id = claim["credentialSubject"]["id"]
-            claim = type_map[claim_id]  # update type claim to use object in type_map - includes inherited properties
+            # update type claim to use object in type_map - includes inherited properties
+            claim = deepcopy(type_map[claim_id])  # must use deepcopy to prevent modification of type_map
 
         if claim["type"] == d3_type_codes["firmware"]:
             firmware_type = claim["credentialSubject"].get("type", None)
@@ -134,6 +136,7 @@ def process_claim_file(
             if claim["credentialSubject"].get("behaviour", None) is None:
                 # if no behaviour of it's own, inherit from parent type to which firmware belongs
                 type_behaviour = type_map[firmware_type]["credentialSubject"].get("behaviour", None)
+                print(type_behaviour)
                 if type_behaviour is not None:
                     claim["credentialSubject"]["behaviour"] = type_behaviour
 

--- a/d3-scripts/tests/__fixtures__/d3-build/behaviour-1.behaviour.d3.yaml
+++ b/d3-scripts/tests/__fixtures__/d3-build/behaviour-1.behaviour.d3.yaml
@@ -8,4 +8,4 @@ credentialSubject:
         ip4:
           protocol: 1
         tcp:
-          destination-port: 1
+          destinationPort: 1

--- a/d3-scripts/tests/__fixtures__/d3-build/behaviour-2.behaviour.d3.yaml
+++ b/d3-scripts/tests/__fixtures__/d3-build/behaviour-2.behaviour.d3.yaml
@@ -8,4 +8,4 @@ credentialSubject:
         ip4:
           protocol: 2
         tcp:
-          destination-port: 2
+          destinationPort: 2

--- a/d3-scripts/tests/__fixtures__/d3-build/behaviour-4.behaviour.d3.yaml
+++ b/d3-scripts/tests/__fixtures__/d3-build/behaviour-4.behaviour.d3.yaml
@@ -10,4 +10,4 @@ credentialSubject:
         ip4:
           protocol: 1
         tcp:
-          destination-port: 2
+          destinationPort: 2

--- a/examples/behaviour-template.behaviour.d3.yaml
+++ b/examples/behaviour-template.behaviour.d3.yaml
@@ -20,9 +20,9 @@ credentialSubject:
       matches:
         # The ipv4 protocol match contains the `protocol` number key,
         # the source-dnsname, which is a string describing a unique web address
-        # the destination-dnsname, which is a string describing a unique web address
+        # the destinationDnsname, which is a string describing a unique web address
         # the source-ipv4, which is a string describing an IPv4 address
-        # the destination-ipv4, which is a string describing an IPv4 address
+        # the destinationIpv4, which is a string describing an IPv4 address
         ip4:
           protocol: 6
           destinationDnsname: dcape-na.amazon.com
@@ -65,22 +65,22 @@ credentialSubject:
           protocol: 17
           destinationIp4: 255.255.255.255/32
         udp:
-          destination-port: 67
+          destinationPort: 67
     - name: from-ipv4-amazonecho-6
       matches:
         eth:
-          destination-mac: ff:ff:ff:ff:ff:ff
+          destinationMac: ff:ff:ff:ff:ff:ff
           # 0x800 => 2048
           ethertype: 2048
         ip4:
           protocol: 17
-          destination-ip4: 255.255.255.255/32
+          destinationIp4: 255.255.255.255/32
         udp:
-          destination-port: 67
+          destinationPort: 67
     - name: from-ipv4-amazonecho-7
       matches:
         ip4:
           protocol: 17
-          destination-ip4: 208.67.220.220/32
+          destinationIp4: 208.67.220.220/32
         udp:
-          destination-port: 53
+          destinationPort: 53

--- a/examples/manufacturers/Amazon/Echo/echo.behaviour.d3.yaml
+++ b/examples/manufacturers/Amazon/Echo/echo.behaviour.d3.yaml
@@ -13,9 +13,9 @@ credentialSubject:
       matches:
         # The ipv4 protocol match contains the `protocol` number key,
         # the source-dnsname, which is a string describing a unique web address
-        # the destination-dnsname, which is a string describing a unique web address
+        # the destinationDnsname, which is a string describing a unique web address
         # the source-ipv4, which is a string describing an IPv4 address
-        # the destination-ipv4, which is a string describing an IPv4 address
+        # the destinationIpv4, which is a string describing an IPv4 address
         ip4:
           protocol: 6
           destinationDnsname: dcape-na.amazon.com
@@ -58,22 +58,22 @@ credentialSubject:
           protocol: 17
           destinationIp4: 255.255.255.255/32
         udp:
-          destination-port: 67
+          destinationPort: 67
     - name: from-ipv4-amazonecho-6
       matches:
         eth:
-          destination-mac: ff:ff:ff:ff:ff:ff
+          destinationMac: ff:ff:ff:ff:ff:ff
           # 0x800 => 2048
           ethertype: 2048
         ip4:
           protocol: 17
-          destination-ip4: 255.255.255.255/32
+          destinationIp4: 255.255.255.255/32
         udp:
-          destination-port: 67
+          destinationPort: 67
     - name: from-ipv4-amazonecho-7
       matches:
         ip4:
           protocol: 17
-          destination-ip4: 208.67.220.220/32
+          destinationIp4: 208.67.220.220/32
         udp:
-          destination-port: 53
+          destinationPort: 53

--- a/manufacturers/A/Amazonco/Echo-dot-plus/echo-dot-plus.type.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo-dot-plus/echo-dot-plus.type.d3.yaml
@@ -1,0 +1,15 @@
+type: d3-device-type-assertion
+credentialSubject:
+  # unique identifiers
+  id: e22b0268-b6ca-42f8-9317-b629e12286ef
+
+  parents:
+    - id: 3ec73667-68e0-4f84-98f6-2b795aff5e05 # Id of parent type to inherit from
+      # Specific properties to inherit
+      properties:
+        - manufacturer
+        - manufacturerUri
+        - tags
+        - behaviour
+
+  name: "Amazon Echo Dot Plus"

--- a/manufacturers/A/Amazonco/Echo-dot/behaviours/echo-dot-v2.behaviour.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo-dot/behaviours/echo-dot-v2.behaviour.d3.yaml
@@ -1,0 +1,20 @@
+# The type of the verified credential
+type: d3-device-type-behaviour
+# Subject if the verfied credential
+credentialSubject:
+  # The GUID denoting the device rule
+  id: 1c312156-7304-4cda-8299-d92eabdc43b3
+  # Rules are specified as an array with two keys name and matches
+  ruleName: "Amazon Echo Dot"
+  # Parent behaviours to inherit rules from
+  parents:
+    - fc4d5a51-f985-4de1-a157-51ea9ca5e9c0 # Id of parent behaviour to inherit from
+rules:
+    - name: firmware-rule-1
+      # The matches key contains the protocols that need to be matched (eth, ipv4, tcp and udp)
+      matches:
+        ip4:
+          protocol: 8
+          destinationDnsname: dcape-na.amazon.com
+        tcp:
+          destinationPort: 446

--- a/manufacturers/A/Amazonco/Echo-dot/behaviours/echo-dot.behaviour.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo-dot/behaviours/echo-dot.behaviour.d3.yaml
@@ -1,0 +1,11 @@
+# The type of the verified credential
+type: d3-device-type-behaviour
+# Subject if the verfied credential
+credentialSubject:
+  # The GUID denoting the device rule
+  id: 2de780eb-9f11-4f10-8a10-5ca62e2e71e6
+  # Rules are specified as an array with two keys name and matches
+  ruleName: "Amazon Echo Dot"
+  # Parent behaviours to inherit rules from
+  parents:
+    - fc4d5a51-f985-4de1-a157-51ea9ca5e9c0 # Id of parent behaviour to inherit from

--- a/manufacturers/A/Amazonco/Echo-dot/echo-dot.type.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo-dot/echo-dot.type.d3.yaml
@@ -1,0 +1,16 @@
+type: d3-device-type-assertion
+credentialSubject:
+  # unique identifiers
+  id: 3ec73667-68e0-4f84-98f6-2b795aff5e05
+  name: "Amazon Echo Dot"
+
+  # behaviour
+  behaviour: 2de780eb-9f11-4f10-8a10-5ca62e2e71e6
+
+  parents:
+    - id: ba3ba36d-be70-40f0-9c52-95b560066d11 # Id of parent type to inherit from
+      # Specific properties to inherit
+      properties:
+        - manufacturer
+        - manufacturerUri
+        - tags

--- a/manufacturers/A/Amazonco/Echo-dot/firmwares/echo-dot-v0.firmware.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo-dot/firmwares/echo-dot-v0.firmware.d3.yaml
@@ -1,0 +1,5 @@
+type: d3-firmware-assertion
+credentialSubject:
+  id: de11df69-1223-455e-bdb4-f492125a72d9 # unique identifier
+  type: 3ec73667-68e0-4f84-98f6-2b795aff5e05 # type for device for which firmware applies
+  versions: "<1.4"

--- a/manufacturers/A/Amazonco/Echo-dot/firmwares/echo-dot-v1.firmware.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo-dot/firmwares/echo-dot-v1.firmware.d3.yaml
@@ -1,0 +1,9 @@
+type: d3-firmware-assertion
+credentialSubject:
+  id: ffaf7fc3-52e1-41b3-80ea-f0cf5dc68933 # unique identifier
+
+  type: 3ec73667-68e0-4f84-98f6-2b795aff5e05 # type for device for which firmware applies
+  behaviour: 2de780eb-9f11-4f10-8a10-5ca62e2e71e6 # behaviour associated with this firmware
+
+  # firmware versions which exhibit corresponding behaviour
+  versions: ">=1.4,<4"

--- a/manufacturers/A/Amazonco/Echo-dot/firmwares/echo-dot-v2.firmware.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo-dot/firmwares/echo-dot-v2.firmware.d3.yaml
@@ -1,0 +1,9 @@
+type: d3-firmware-assertion
+credentialSubject:
+  id: 15757498-940d-48dc-8db0-3e3a8943776f # unique identifier
+
+  type: 3ec73667-68e0-4f84-98f6-2b795aff5e05 # type for device for which firmware applies
+  behaviour: 1c312156-7304-4cda-8299-d92eabdc43b3 # behaviour associated with this firmware
+
+  # firmware versions which exhibit corresponding behaviour
+  versions: ">4.0"

--- a/manufacturers/A/Amazonco/Echo/echo.behaviour.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo/echo.behaviour.d3.yaml
@@ -1,0 +1,79 @@
+# The type of the verified credential
+type: d3-device-type-behaviour
+# Subject if the verfied credential
+credentialSubject:
+  # The GUID denoting the device rule
+  id: fc4d5a51-f985-4de1-a157-51ea9ca5e9c0
+  # Rules are specified as an array with two keys name and matches
+  ruleName: "Amazon Echo"
+  rules:
+    # The name key string doesn't need to be unique. It is a brief description of the rule
+    - name: from-ipv4-amazonecho-0
+      # The matches key contains the protocols that need to be matched (eth, ipv4, tcp and udp)
+      matches:
+        # The ipv4 protocol match contains the `protocol` number key,
+        # the source-dnsname, which is a string describing a unique web address
+        # the destination-dnsname, which is a string describing a unique web address
+        # the source-ipv4, which is a string describing an IPv4 address
+        # the destination-ipv4, which is a string describing an IPv4 address
+        ip4:
+          protocol: 6
+          destinationDnsname: dcape-na.amazon.com
+        # The tcp protocol match contains the source-port and destination port
+        tcp:
+          destinationPort: 443
+    - name: from-ipv4-amazonecho-1
+      matches:
+        ip4:
+          protocol: 6
+          destinationDnsname: softwareupdates.amazon.com
+        tcp:
+          destinationPort: 443
+    - name: from-ipv4-amazonecho-2
+      matches:
+        ip4:
+          protocol: 17
+          destinationDnsname: 3.north-america.pool.ntp.org
+        udp:
+          destinationPort: 123
+    - name: from-ipv4-amazonecho-3
+      matches:
+        ip4:
+          protocol: 2
+          destinationIp4: 224.0.0.22/32
+    - name: from-ipv4-amazonecho-4
+      matches:
+        ip4:
+          protocol: 17
+          destinationIp4: 239.255.255.250/32
+        udp:
+          destinationPort: 1900
+    - name: from-ipv4-amazonecho-5
+      matches:
+        eth:
+          destinationMac: ff:ff:ff:ff:ff:ff
+          # 0x800 => 2048
+          ethertype: 2048
+        ip4:
+          protocol: 17
+          destinationIp4: 255.255.255.255/32
+        udp:
+          destination-port: 67
+    - name: from-ipv4-amazonecho-6
+      matches:
+        eth:
+          destination-mac: ff:ff:ff:ff:ff:ff
+          # 0x800 => 2048
+          ethertype: 2048
+        ip4:
+          protocol: 17
+          destination-ip4: 255.255.255.255/32
+        udp:
+          destination-port: 67
+    - name: from-ipv4-amazonecho-7
+      matches:
+        ip4:
+          protocol: 17
+          destination-ip4: 208.67.220.220/32
+        udp:
+          destination-port: 53

--- a/manufacturers/A/Amazonco/Echo/echo.behaviour.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo/echo.behaviour.d3.yaml
@@ -13,9 +13,9 @@ credentialSubject:
       matches:
         # The ipv4 protocol match contains the `protocol` number key,
         # the source-dnsname, which is a string describing a unique web address
-        # the destination-dnsname, which is a string describing a unique web address
+        # the destinationDnsname, which is a string describing a unique web address
         # the source-ipv4, which is a string describing an IPv4 address
-        # the destination-ipv4, which is a string describing an IPv4 address
+        # the destinationIpv4, which is a string describing an IPv4 address
         ip4:
           protocol: 6
           destinationDnsname: dcape-na.amazon.com
@@ -58,22 +58,22 @@ credentialSubject:
           protocol: 17
           destinationIp4: 255.255.255.255/32
         udp:
-          destination-port: 67
+          destinationPort: 67
     - name: from-ipv4-amazonecho-6
       matches:
         eth:
-          destination-mac: ff:ff:ff:ff:ff:ff
+          destinationMac: ff:ff:ff:ff:ff:ff
           # 0x800 => 2048
           ethertype: 2048
         ip4:
           protocol: 17
-          destination-ip4: 255.255.255.255/32
+          destinationIp4: 255.255.255.255/32
         udp:
-          destination-port: 67
+          destinationPort: 67
     - name: from-ipv4-amazonecho-7
       matches:
         ip4:
           protocol: 17
-          destination-ip4: 208.67.220.220/32
+          destinationIp4: 208.67.220.220/32
         udp:
-          destination-port: 53
+          destinationPort: 53

--- a/manufacturers/A/Amazonco/Echo/echo.type.d3.yaml
+++ b/manufacturers/A/Amazonco/Echo/echo.type.d3.yaml
@@ -1,0 +1,19 @@
+type: d3-device-type-assertion
+credentialSubject:
+  # unique identifiers
+  id: ba3ba36d-be70-40f0-9c52-95b560066d11
+
+  # behaviour
+  behaviour: fc4d5a51-f985-4de1-a157-51ea9ca5e9c0
+
+  # specific information
+  tags: "#assistant"
+  name: "Amazon Echo"
+
+  parents:
+    - id: b2a471c6-3c2e-5b2a-927d-dd9b5aa44f69 # Id of parent type to inherit from
+      # Specific properties to inherit
+      properties:
+        - manufacturer
+        - manufacturerUri
+


### PR DESCRIPTION
Added parents and children of types to types csv.
Added parents and children to SQL types table.
Added firmware table to SQL.

Added example toy inheriting types for amazon echo, echo dot and echo dot plus.

Fixed malformed dash-separated behaviour properties.
Fixed bug with claim behaviour in type_map getting overwritten by reference.
