### PR TITLE
ci: only build on main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,11 @@ jobs:
     runs-on: ubuntu-latest
     # d3build is slow, so only run if lint/tests pass
     needs: [pre-commit, test, d3lint]
+    # Only run on main branch, as the build is resource intensive
+    if:
+      contains('
+        refs/heads/main
+      ', github.ref)
     defaults:
       run:
         working-directory: d3-scripts


### PR DESCRIPTION
- only run build action on main branch due to time/resources required