### PR TITLE
MUD parity for behaviours

### DIFF
--- a/D3DB/tables.sql
+++ b/D3DB/tables.sql
@@ -33,7 +33,9 @@ CREATE TABLE "behaviour" (
 CREATE TABLE "behaviour_eth" (
   "ruleid" TEXT NOT NULL,
   "sourcemac" TEXT,
+  "sourcemacmask" TEXT,
   "destinationmac" TEXT,
+  "destinationmacmask" TEXT,
   "ethertype" NUMERIC NOT NULL,
   PRIMARY KEY("ruleid")
 )
@@ -45,6 +47,24 @@ CREATE TABLE "behaviour_ip4" (
   "sourcednsname" TEXT,
   "destinationdnsname" TEXT,
   "protocol" NUMERIC NOT NULL,
+  "ihl" NUMERIC,
+  "tos" NUMERIC,
+  "ttl" NUMERIC,
+  "offset" NUMERIC,
+  "length" NUMERIC,
+  PRIMARY KEY("ruleid")
+)
+
+CREATE TABLE "behaviour_ip6" (
+  "ruleid" TEXT NOT NULL,
+  "sourceip6" TEXT,
+  "destinationip6" TEXT,
+  "sourcednsname" TEXT,
+  "destinationdnsname" TEXT,
+  "protocol" NUMERIC NOT NULL,
+  "ttl" NUMERIC,
+  "flowlabel" NUMERIC,
+  "length" NUMERIC,
   PRIMARY KEY("ruleid")
 )
 
@@ -59,5 +79,12 @@ CREATE TABLE "behaviour_udp" (
   "ruleid" TEXT NOT NULL,
   "sourceport" INTEGER,
   "destinationport" INTEGER,
+  PRIMARY KEY("ruleid")
+)
+
+CREATE TABLE "behaviour_icmp" (
+  "ruleid" TEXT NOT NULL,
+  "type" INTEGER,
+  "code" INTEGER,
   PRIMARY KEY("ruleid")
 )

--- a/d3-scripts/src/d3_scripts/d3_constants.py
+++ b/d3-scripts/src/d3_scripts/d3_constants.py
@@ -14,7 +14,7 @@ d3_type_codes_to_schemas = {
 d3_types = d3_type_codes.keys()
 d3_codes = d3_type_codes.values()
 
-behaviour_rule_types = ["eth", "ip4", "tcp", "udp"]
+behaviour_rule_types = ["eth", "ip4", "ip6" "tcp", "udp", "icmp"]
 
 csv_headers = {
     "type": [

--- a/d3-scripts/src/d3_scripts/schemas/behaviour.json
+++ b/d3-scripts/src/d3_scripts/schemas/behaviour.json
@@ -35,7 +35,7 @@
               "ip4": {
                 "title": "behaviour-ip4",
                 "type": "object",
-                "description": "The ip v4 protocol behaviour rule",
+                "description": "The IP v4 protocol behaviour rule",
                 "properties": {
                   "sourceIp4": {
                     "type": "string",
@@ -49,15 +49,76 @@
                   },
                   "sourceDnsName": {
                     "type": "string",
-                    "description": "The source dns address"
+                    "description": "The source DNS address"
                   },
                   "destinationDnsName": {
                     "type": "string",
-                    "description": "The destination dns address"
+                    "description": "The destination DNS address"
                   },
                   "protocol": {
                     "type": "number",
                     "description": "The protocol number"
+                  },
+                  "ihl": {
+                    "type": "number",
+                    "description": "The IP header length"
+                  },
+                  "tos": {
+                    "type": "number",
+                    "description": "The IP type of service"
+                  },
+                  "ttl": {
+                    "type": "number",
+                    "description": "The IP time to live"
+                  },
+                  "offset": {
+                    "type": "number",
+                    "description": "The IP offset"
+                  },
+                  "length": {
+                    "type": "number",
+                    "description": "The IP packet length"
+                  }
+                }
+              },
+              "ip6": {
+                "title": "behaviour-ip6",
+                "type": "object",
+                "description": "The IP v6 protocol behaviour rule",
+                "properties": {
+                  "sourceIp6": {
+                    "type": "string",
+                    "format": "ipv6",
+                    "description": "The source IPv6 address"
+                  },
+                  "destinationIp6": {
+                    "type": "string",
+                    "format": "ipv6",
+                    "description": "The destination IPv6 address"
+                  },
+                  "sourceDnsName": {
+                    "type": "string",
+                    "description": "The source DNS address"
+                  },
+                  "destinationDnsName": {
+                    "type": "string",
+                    "description": "The destination DNS address"
+                  },
+                  "protocol": {
+                    "type": "number",
+                    "description": "The protocol number"
+                  },
+                  "ttl": {
+                    "type": "number",
+                    "description": "The IP time to live"
+                  },
+                  "length": {
+                    "type": "number",
+                    "description": "The IP packet length"
+                  },
+                  "flowLabel": {
+                    "type": "number",
+                    "description": "The IPv6 flow label"
                   }
                 }
               },
@@ -71,10 +132,20 @@
                     "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
                     "description": "The source MAC address"
                   },
+                  "sourceMacMask": {
+                    "type": "string",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+                    "description": "The source MAC address mask"
+                  },
                   "destinationMac": {
                     "type": "string",
                     "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
                     "description": "The destination MAC address"
+                  },
+                  "destinationMacMask": {
+                    "type": "string",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+                    "description": "The source MAC address mask"
                   },
                   "etherType": {
                     "type": "number",
@@ -109,6 +180,21 @@
                   "destinationPort": {
                     "type": "number",
                     "description": "The destination ports"
+                  }
+                }
+              },
+              "icmp": {
+                "title": "behaviour-icmp",
+                "description": "The ICMP protocol behaviour rule",
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "number",
+                    "description": "The ICMP type"
+                  },
+                  "code": {
+                    "type": "number",
+                    "description": "The ICMP code"
                   }
                 }
               }


### PR DESCRIPTION
This PR increases parity between the ACL type from the MUD specification (https://tools.ietf.org/id/draft-ietf-netmod-acl-model-17.html#aclmodules) and the behaviour schema where applicable.