### PR TITLE
fix: remove deprecated cmd line arg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install d3-cli
         run: pip install --upgrade d3-cli
       - name: Validate D3 files, convert to JSON and Export D3 JSON files into CSV
-        run: d3-cli manufacturers --mode export --output D3DB --skip-vuln --skip-mal
+        run: d3-cli manufacturers --mode export --output D3DB --skip-mal
       - name: Deploy CSV files to `csv` branch (`main` branch only)
         if: github.ref == 'refs/heads/main'
         uses: s0/git-publish-subdir-action@v2.5.1


### PR DESCRIPTION
Remove deprecated command line arg in d3-cli export command causing CI to fail to build csv branch.