### PR TITLE
ci(d3build): limit d3build to a single build at a time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
         run: d3-cli manufacturers --mode lint
   d3build:
     name: Run D3 Build
+    environment:
+      name: d3db-csv
+      url: https://github.com/TechWorksHub/ManySecured-D3DB/tree/csv
+    concurrency: d3db-csv # limit to a single-run build at a time
     permissions:
       # required to make a new commit in the `csv` branch
       contents: write


### PR DESCRIPTION
Create a GitHub Actions `environment` (see https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) in order to limit the `d3build` GitHub Action to run a single instance at a time.

This avoids race-conditions that might appear when running two `d3builds` in close succession (e.g. when merging two PRs right after each other).